### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note that you can also have it as the second parameter - this is primarily inten
 ## Installation
 
 ```
-go get github.com/kulti/thelper/cmd/thelper
+go install github.com/kulti/thelper/cmd/thelper@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go get` currently modifies the `go.mod` file and that's probably not what you want installing a linter. Use `go install` instead.

https://go.dev/ref/mod