### PR TITLE
🤫 Don't require t.Helper in functions passed to synctest.Test

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -516,9 +516,7 @@ func extractSynctestExp(
 		return nil
 	}
 
-	// Simple check: if the identifier is "synctest", assume it's the right package
-	// This is a heuristic approach similar to how other linters work
-	if ident.Name != "synctest" {
+	if !isIdentPackageName(pass, ident, "testing/synctest") {
 		return nil
 	}
 
@@ -637,6 +635,21 @@ func isExprHasType(pass *analysis.Pass, expr ast.Expr, expType types.Type) bool 
 	}
 
 	return types.Identical(typeInfo.Type, expType)
+}
+
+// isIdentPackageName returns true if ident refers to the specified package.
+func isIdentPackageName(pass *analysis.Pass, ident *ast.Ident, pkgName string) bool {
+	obj := pass.TypesInfo.Uses[ident]
+	if obj == nil {
+		return false
+	}
+
+	pkgObj, ok := obj.(*types.PkgName)
+	if !ok {
+		return false
+	}
+
+	return pkgObj.Imported().Path() == pkgName
 }
 
 // findSelectorDeclaration returns function declaration called by selector expression.

--- a/pkg/analyzer/testdata/src/t/s.go
+++ b/pkg/analyzer/testdata/src/t/s.go
@@ -2,7 +2,6 @@ package t
 
 import (
 	"testing"
-	"testing/synctest"
 )
 
 func TestSubtestWithAnonymous(t *testing.T) {
@@ -57,31 +56,4 @@ type subtestFixture struct{}
 
 func (f subtestFixture) subtest() func(t *testing.T) {
 	return func(t *testing.T) {}
-}
-
-// Test cases for synctest.Test - similar to t.Run tests
-func TestSynctestWithAnonymous(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {})
-}
-
-func TestSynctest(t *testing.T) {
-	h := subhelper{}
-	synctest.Test(t, check)
-	synctest.Test(t, h.check)
-}
-
-func TestSynctestWithHelperAsTest(t *testing.T) {
-	h := subhelper{}
-	synctest.Test(t, anotherCheck)
-	synctest.Test(t, h.anotherCheck)
-}
-
-func TestSynctestWithBuilder(t *testing.T) {
-	synctest.Test(t, subtestBuilder("first"))
-	synctest.Test(t, subtestBuilder("second"))
-	synctest.Test(t, subtestBuilderAnotherFile())
-	synctest.Test(t, func() func(t *testing.T) { return func(t *testing.T) {} }())
-
-	fixture := subtestFixture{}
-	synctest.Test(t, fixture.subtest())
 }

--- a/pkg/analyzer/testdata/src/t/sy.go
+++ b/pkg/analyzer/testdata/src/t/sy.go
@@ -1,0 +1,32 @@
+package t
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func TestSynctestWithAnonymous(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {})
+}
+
+func TestSynctest(t *testing.T) {
+	h := subhelper{}
+	synctest.Test(t, check)
+	synctest.Test(t, h.check)
+}
+
+func TestSynctestWithHelperAsTest(t *testing.T) {
+	h := subhelper{}
+	synctest.Test(t, anotherCheck)
+	synctest.Test(t, h.anotherCheck)
+}
+
+func TestSynctestWithBuilder(t *testing.T) {
+	synctest.Test(t, subtestBuilder("first"))
+	synctest.Test(t, subtestBuilder("second"))
+	synctest.Test(t, subtestBuilderAnotherFile())
+	synctest.Test(t, func() func(t *testing.T) { return func(t *testing.T) {} }())
+
+	fixture := subtestFixture{}
+	synctest.Test(t, fixture.subtest())
+}


### PR DESCRIPTION
Go 1.25 made the `testing/synctest` package generally available. The
package introduces the `synctest.Test` function, to be used like this:

```go
func TestMyFeature(t *testing.T) {
	synctest.Test(t, func(t *testing.T) {
		// Do stuff that uses goroutines
	})
}
```

Sadly, `thelper` triggers if the anonymous function passed to
`synctest.Test` doesn't call `t.Helper()`. The issue is that this
anonymous function isn't a helper, it's more like a sub-test. This
has been reported in #48.

This PR extends `thelper` to grant an exception to functions passed to
`synctest.Test`, just like functions passed to `t.Run` or `b.Run`.

This requires updating to Go 1.25, so this PR is stacked on top of https://github.com/kulti/thelper/pull/50.